### PR TITLE
[ENH] Use Dask to load HDF5/v7.3 .mat images faster

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dask
 h5py
 numpy
 pluggy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask
+dask[delayed]
 h5py
 numpy
 pluggy

--- a/tests/test_mat_images.py
+++ b/tests/test_mat_images.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import os
 from tempfile import NamedTemporaryFile
 
 import hdf5storage


### PR DESCRIPTION
# PR Description

Please describe the changes proposed in the pull request:

- Larger .mat files saved using `HDF5` are chunked and can be loaded lazily using `Dask` chunking
- Multidimensional images are sampled to set contrast min/max. Faster than forcing `napari` to do so

<!-- Doing so provides maintainers with context on what the PR is, and can help us more effectively review your PR. -->

<!-- Please also identify below which issue that has been raised that you are going to close. -->

**This PR resolves #3.**

## Quick Check

To do a very quick check that everything is correct, run the following commands from the plugin's top level directory:

[X] `$ black`
[X] `$ pytest .`

## Code Changes


If you are adding code changes, please ensure the following:

- [ ] Ensure that you have added tests.
- [X] Run all tests (`$ pytest .`) locally on your machine.
    - [X] Check to ensure that test coverage covers the lines of code that you have added.
    - [X] Ensure that all tests pass.

# Relevant Reviewers

<!-- Finally, please tag relevant maintainers to review. -->

Please tag maintainers to review.

- @hectormz
